### PR TITLE
kernel:   Allow user to define there path to  custom LLVM binutils

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -262,7 +262,7 @@ endif
 
 # As
 ifeq ($(KERNEL_SUPPORTS_LLVM_TOOLS),true)
-    LLVM_TOOLS ?= $(TARGET_KERNEL_CLANG_PATH)/bin
+    LLVM_TOOLS := $(KERNEL_TOOLCHAIN)
     KERNEL_LD := LD=$(LLVM_TOOLS)/ld.lld
     KERNEL_AR := AR=$(LLVM_TOOLS)/llvm-ar
     KERNEL_OBJCOPY := OBJCOPY=$(LLVM_TOOLS)/llvm-objcopy


### PR DESCRIPTION
-Remove TARGET_KERNEL_CLANG_PATH as the default path to custom LLVM binutils for LLVM_TOOLS var.
-Set the path to KERNEL_TOOLCHAIN .